### PR TITLE
Fix camera initialization and seek behavior

### DIFF
--- a/client/src/components/VideoPlayer.tsx
+++ b/client/src/components/VideoPlayer.tsx
@@ -114,9 +114,11 @@ export function VideoPlayer({
   };
 
   const handleSeek = (value: number[]) => {
-    if (videoRef.current) {
-      videoRef.current.currentTime = value[0];
-      setCurrentTime(value[0]);
+    if (!videoRef.current) return;
+    const newTime = value[0];
+    if (Number.isFinite(newTime)) {
+      videoRef.current.currentTime = newTime;
+      setCurrentTime(newTime);
     }
   };
 

--- a/client/src/components/VideoRecorder.tsx
+++ b/client/src/components/VideoRecorder.tsx
@@ -67,8 +67,13 @@ export function VideoRecorder({ onRecordingComplete, onCancel }: VideoRecorderPr
       if (videoRef.current) {
         videoRef.current.srcObject = stream;
         videoRef.current.muted = true; // Prevent feedback
-        // Ensure video plays automatically once the stream is set
-        videoRef.current.play().catch(console.error);
+
+        // Ensure video plays once metadata is available
+        const playVideo = () => {
+          videoRef.current?.play().catch(console.error);
+          videoRef.current?.removeEventListener('loadedmetadata', playVideo);
+        };
+        videoRef.current.addEventListener('loadedmetadata', playVideo);
       }
       
       setIsInitializing(false);
@@ -178,7 +183,12 @@ export function VideoRecorder({ onRecordingComplete, onCancel }: VideoRecorderPr
     if (videoRef.current) {
       videoRef.current.srcObject = streamRef.current;
       videoRef.current.muted = true;
-      videoRef.current.play().catch(console.error);
+
+      const playVideo = () => {
+        videoRef.current?.play().catch(console.error);
+        videoRef.current?.removeEventListener('loadedmetadata', playVideo);
+      };
+      videoRef.current.addEventListener('loadedmetadata', playVideo);
     }
   };
 


### PR DESCRIPTION
## Summary
- ensure VideoRecorder plays camera stream after metadata loads
- replay the stream correctly when recording again
- guard against invalid values in VideoPlayer seek handler

## Testing
- `npm run check` *(fails: cannot find type definition file for 'node', plus other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e170198a48329ab5d0f09ca476c50